### PR TITLE
Added ObjectId message & detection to deep equality assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Ignore JetBrains configurations
+.idea
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/Grader.js
+++ b/Grader.js
@@ -119,7 +119,7 @@ export default class Grader {
       // Since the stringification between "expected" and "result" is misleading, this gives a note
       //   to the student urging them to check that their obj_id
       let obj_id_exists = "";
-      let obj_id_message = "\n*** Note: Are your ObjectId's passed as the wrong type? ***";
+      let obj_id_message = "\n*** Note: id is an ObjectId, but must be converted to string. ***";
       if (Array.isArray(actual)) {
         let res = findAllObjectIdsInArray(actual);
         res.length > 0

--- a/Grader.js
+++ b/Grader.js
@@ -121,16 +121,15 @@ export default class Grader {
       //   to the student urging them to check that their obj_id
       let obj_id_exists = "";
       if (this.printObjectIdMessage) {
-        let obj_id_message = "\n*** Note: id is an ObjectId, but must be converted to string. ***";
         if (Array.isArray(actual)) {
           let res = findAllObjectIdsInArray(actual);
           res.length > 0
-            ? obj_id_exists = obj_id_message
+            ? obj_id_exists = `\n*** Note: the field(s) ${JSON.stringify(res)} is/are ObjectId(s), but must be converted to string. ***`
             : obj_id_exists = "";
         } else if (actual instanceof Object) {
           let res = findAllObjectIdsInObj(actual);
           Object.keys(res).length > 0
-            ? obj_id_exists = obj_id_message
+            ? obj_id_exists = `\n*** Note: the value(s) at key(s) ${JSON.stringify(Object.keys(res))} is/are ObjectId(s), but must be converted to string. ***`
             : obj_id_exists = "";
         }
       }
@@ -399,7 +398,7 @@ Server either didn't start, is at an unexpected URL, or crashed during the previ
       throw e;
     }
     if (res.status !== 200) {
-      throw new Error("HTML Validator Error: 503 Service Temporarily Unavailable. Please try again in a moment.")
+      throw new Error(`"HTML Validator Error gave bad response: ${res.status} ${res.statusText}. Please re-run grader again later."`)
     }
     const { messages } = await res.json();
     for (const message of messages) {

--- a/Grader.js
+++ b/Grader.js
@@ -92,10 +92,10 @@ export default class Grader {
             newArr.push(`[${i}]`);
           } else if (Array.isArray(item)) {
             let res = findAllObjectIdsInArray(item);
-            newArr.push(*res.map(subItem => `[${i}]${subItem}`));
+            newArr.push(...res.map(subItem => `[${i}]${subItem}`));
           } else if (item instanceof Object) {
             let res = findAllObjectIdsInObj(item);
-            newArr.push(*res.map(subItem => `[${i}]${subItem}`));
+            newArr.push(...res.map(subItem => `[${i}]${subItem}`));
           }
         }
         return newArr;
@@ -103,15 +103,15 @@ export default class Grader {
 
       const findAllObjectIdsInObj = (obj) => {
         let newArr = [];
-        for (let key of Object.keys(obj)) {
+        for (let key in obj) {
           if (ObjectId.isValid(obj[key]) && typeof obj[key] === 'object' && obj[key]._bsontype === 'ObjectId') {
             newArr.push(`.${key}`);
           } else if (Array.isArray(obj[key])) {
             let res = findAllObjectIdsInArray(obj[key]);
-            newArr.push(*res.map(subItem => `.${key}${subItem}`));
+            newArr.push(...res.map(subItem => `.${key}${subItem}`));
           } else if (obj[key] instanceof Object) {
             let res = findAllObjectIdsInObj(obj[key]);
-            newArr.push(*res.map(subItem => `.${key}${subItem}`));
+            newArr.push(...res.map(subItem => `.${key}${subItem}`));
           }
         }
         return newArr;
@@ -134,7 +134,7 @@ export default class Grader {
         ? ` ObjectId type found at the following key(s) instead of type string: "${keys.join('", "')}"`
         : "";
 
-      this.deductPoints(points, `${message}; Unexpected results.${obj_id_exists}`,
+      this.deductPoints(points, `${message}; Unexpected results.${objIdErrMsg}`,
         `Received: ${pretty(actual)}\nExpected: ${pretty(expectedValue)}`);
     }
   }


### PR DESCRIPTION
Stringification of objectID can be misleading, so a note was added to tell students they returned an ObjectID rather than a string.